### PR TITLE
Upgrade to Python 3.13 and fix Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,8 @@ ENV POETRY_HOME="/opt/poetry"
 ENV PATH="$POETRY_HOME/bin:$PATH"
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 
-RUN dnf install -y gcc gcc-c++ make libffi-devel python3-devel \
+RUN dnf install -y gcc gcc-c++ gcc-gfortran make cmake libffi-devel python3-devel \
+    && dnf upgrade -y gcc gcc-c++ \
     && curl -sSL https://install.python-poetry.org | python3 -
 
 WORKDIR /var/task

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,10 @@
-FROM public.ecr.aws/lambda/python:3.11
+FROM public.ecr.aws/lambda/python:3.13
 
 ENV POETRY_HOME="/opt/poetry"
 ENV PATH="$POETRY_HOME/bin:$PATH"
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 
-RUN yum install -y gcc gcc-c++ make libffi-devel python3-devel \
+RUN dnf install -y gcc gcc-c++ make libffi-devel python3-devel \
     && curl -sSL https://install.python-poetry.org | python3 -
 
 WORKDIR /var/task
@@ -15,7 +15,7 @@ RUN poetry install --no-interaction --no-root
 
 COPY src .
 
-RUN mkdir -p /opt/python && cp -r .venv/lib/python3.11/site-packages/* /opt/python/
+RUN mkdir -p /opt/python && cp -r .venv/lib/python3.13/site-packages/* /opt/python/
 
 ENV PYTHONPATH=/opt/python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
     package-mode = false
 
     [tool.poetry.dependencies]
-    python = "^3.11"
+    python = "^3.13"
     pandas = "^2.2.3"
     boto3 = "^1.35.68"
     loguru = "^0.7.2"


### PR DESCRIPTION
- Updated Dockerfile to use Python 3.13 Lambda base image
- Changed package manager from yum to dnf (Amazon Linux 2023)
- Updated pyproject.toml to require Python 3.13
- Fixes NumPy build failure due to old GCC in Python 3.11 image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description


# Review Time
- [ ] <10
- [ ] 10-30
- [ ] 30-60
- [ ] 60+ (Make it smaller)

# Checklist:

- [ ] numpy style guide - "Readability Counts" 
- [ ] If necessary, I have updated the readme
